### PR TITLE
allow possibility to change graph heigh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ node_modules
 .env.development.local
 .env.test.local
 .env.production.local
+.npmrc
 
 npm-debug.log*
 yarn-debug.log*

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -8,7 +8,7 @@ const App = () => {
     <div style={{ width: '500px' }}>
       <Chart
         title="Number of messages"
-        chartHeight="100%"
+        height="100%"
         chartType="line"
         series={[
           {

--- a/src/components/_organisms/Chart/Chart.component.tsx
+++ b/src/components/_organisms/Chart/Chart.component.tsx
@@ -16,7 +16,7 @@ export type TitleStyle = {
 
 export type ChartProps = {
   series: ChartSeries[];
-  chartHeight: number | string;
+  height?: string;
   colors: string[]; // line colors
   gradientToColors: string[];
   title?: string;
@@ -36,7 +36,7 @@ const Chart: React.FC<ChartProps> = (props: ChartProps): JSX.Element => {
     title = '',
     chartType,
     series,
-    chartHeight,
+    height = '100%',
     colors,
     strokeWidths,
     gradientToColors,
@@ -189,7 +189,7 @@ const Chart: React.FC<ChartProps> = (props: ChartProps): JSX.Element => {
     <ReactApexChart
       options={state.options}
       series={state.options.series}
-      height={chartHeight}
+      height={height}
     />
   );
 };

--- a/src/components/_organisms/Chart/Chart.component.tsx
+++ b/src/components/_organisms/Chart/Chart.component.tsx
@@ -34,9 +34,9 @@ export type ChartProps = {
 const Chart: React.FC<ChartProps> = (props: ChartProps): JSX.Element => {
   const {
     title = '',
-    chartHeight,
     chartType,
     series,
+    chartHeight,
     colors,
     strokeWidths,
     gradientToColors,
@@ -85,7 +85,6 @@ const Chart: React.FC<ChartProps> = (props: ChartProps): JSX.Element => {
         style: titleStyle,
       },
       chart: {
-        height: chartHeight,
         type: chartType,
         toolbar: {
           show: false,
@@ -187,7 +186,11 @@ const Chart: React.FC<ChartProps> = (props: ChartProps): JSX.Element => {
   };
 
   return (
-    <ReactApexChart options={state.options} series={state.options.series} />
+    <ReactApexChart
+      options={state.options}
+      series={state.options.series}
+      height={chartHeight}
+    />
   );
 };
 

--- a/src/components/_organisms/Chart/Chart.spec.tsx
+++ b/src/components/_organisms/Chart/Chart.spec.tsx
@@ -8,7 +8,7 @@ test('Chart renders correctly', () => {
   const component = renderer.render(
     <Chart
       title="Number of messages"
-      chartHeight="100%"
+      height="100%"
       chartType="line"
       series={[
         {

--- a/src/components/_organisms/Chart/Chart.stories.mdx
+++ b/src/components/_organisms/Chart/Chart.stories.mdx
@@ -17,7 +17,7 @@ This is an implementation of the Chart Component
     <div style={{height: '500px', width: '500px' }}>
     <Chart
       title="Number of messages"
-      chartHeight="100%"
+      height="100%"
       chartType="line"
       series={[
         {
@@ -47,7 +47,7 @@ This is an implementation of the Chart Component
     <div style={{height: '500px', width: '500px' }}>
       <Chart
         title="Number of users"
-        chartHeight="100%"
+        height="100%"
         chartType="line"
         series={[
           {

--- a/src/components/_organisms/Chart/__snapshots__/Chart.spec.tsx.snap
+++ b/src/components/_organisms/Chart/__snapshots__/Chart.spec.tsx.snap
@@ -2,11 +2,10 @@
 
 exports[`Chart renders correctly 1`] = `
 <r
-  height="auto"
+  height="100%"
   options={
     Object {
       "chart": Object {
-        "height": "100%",
         "toolbar": Object {
           "show": false,
         },


### PR DESCRIPTION
As the height of the graph was 100% and after changing the parent height it didn't influence the size of the graph, I removed the height key from options and put chartHeight as prop directly to the component (tested in Storybook).
This fix is needed for changing chart height on different breakpoints for a better view.